### PR TITLE
Add infrastructure and configuration files for OwnCloud setup

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/aws.xml
+++ b/.idea/aws.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="accountSettings">
+    <option name="activeProfile" value="profile:default" />
+    <option name="activeRegion" value="us-east-1" />
+    <option name="recentlyUsedProfiles">
+      <list>
+        <option value="profile:default" />
+      </list>
+    </option>
+    <option name="recentlyUsedRegions">
+      <list>
+        <option value="us-east-1" />
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/material_theme_project_new.xml
+++ b/.idea/material_theme_project_new.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MaterialThemeProjectNewConfig">
+    <option name="metadata">
+      <MTProjectMetadataState>
+        <option name="migrated" value="true" />
+        <option name="pristineConfig" value="false" />
+        <option name="userId" value="52d9356e:18c58c51382:-8000" />
+        <option name="version" value="8.13.2" />
+      </MTProjectMetadataState>
+    </option>
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/owncloud-solution.iml" filepath="$PROJECT_DIR$/.idea/owncloud-solution.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/owncloud-solution.iml
+++ b/.idea/owncloud-solution.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.75.1"
+  hashes = [
+    "h1:uz55I4t3Pqy3p+82NZ35mkUA9mZ5yu4pS6beZMI8wpA=",
+    "zh:1075825e7311a8d2d233fd453a173910e891b0320e8a7698af44d1f90b02621d",
+    "zh:203c5d09a03fcaa946defb8459f01227f2fcda07df768f74777beb328d6751ae",
+    "zh:21bc79ccb09bfdeb711a3a5226c6c4a457ac7c4bb781dbda6ade7be38461739f",
+    "zh:2bac969855b62a0ff6716954be29387a1f9793626059122cda4681206396e309",
+    "zh:4b65ea5b51058f05b9ec8797f76184e19e5b38a609029fe2226af3fa4ad289b3",
+    "zh:5065d7df357fb3ee2b0a2520bbcff6335c0c47bfb9e8e9932bad088c3ab7efd3",
+    "zh:678a4015a4cd26af5c2b30dfd9290b8a01e900668fa0fec6585dfd1838f1cebd",
+    "zh:6ddc5dfdd4a0dddca027db99a7bfa9a0978933119d63af81acb6020728405119",
+    "zh:98c0d48b09842c444dbcbddd279e5b5b1e44113951817a8ecc28896bb4ad1dd7",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:aad169fea072842c0b54f1ff95f1ec6558d6c5af3ea4c159308583db59003b09",
+    "zh:bd2625ed8e1ff29ac6ed3a810d7b68a090add5fcb2fce4122669bd37e1eb9f1d",
+    "zh:c6f57625e26a6ef1ffb49bfa0e6148496ad12d80c857f6bb222e21f293a2a78a",
+    "zh:c7cd085326c5eb88804b11a4bc0fbc8376f06138f4b9624fb25cd06ea8687cdd",
+    "zh:f60c98139f983817d4d08f4138b1e53f31f91176ff638631e8dd38b6de36fce0",
+  ]
+}

--- a/ec2-instances.tf
+++ b/ec2-instances.tf
@@ -1,0 +1,32 @@
+resource "aws_instance" "owncloud-server" {
+  ami                         = var.ubuntu_ami
+  instance_type               = "t2.micro"
+  subnet_id                   = aws_subnet.public_subnet.id
+  associate_public_ip_address = true
+  key_name                    = var.key_pair
+
+  vpc_security_group_ids = [aws_security_group.public_sg.id]
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "owncloud-server"
+    }
+  )
+}
+
+resource "aws_instance" "mysql-server" {
+  ami           = var.ubuntu_ami
+  instance_type = "t2.micro"
+  subnet_id     = aws_subnet.private_subnet.id
+  key_name      = var.key_pair
+
+  vpc_security_group_ids = [aws_security_group.private_sg.id]
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "mysql-server"
+    }
+  )
+}

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -1,0 +1,59 @@
+resource "aws_security_group" "public_sg" {
+  vpc_id = aws_vpc.owncloud-vpc.id
+
+  description = "Opens port for SSH and HTTP"
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.ssh_allowed_ip]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "public-server-SG"
+    }
+  )
+}
+
+resource "aws_security_group" "private_sg" {
+  vpc_id = aws_vpc.owncloud-vpc.id
+
+  # mysql
+  ingress {
+    from_port = 3306
+    to_port   = 3306
+    protocol  = "tcp"
+  }
+
+  # bastion setup
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["${aws_instance.owncloud-server.private_ip}/32"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,47 @@
+variable "aws_region" {
+  description = "AWS region."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "vpc_cidr_block" {
+  description = "CIDR block for VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "vpc_name" {
+  description = "Name of VPC."
+  type        = string
+  default     = "owncloud-vpc"
+}
+
+variable "public_subnet_cidr_block" {
+  description = "The CIDR block for the public subnet"
+  type        = string
+  default     = "10.0.1.0/24"
+}
+
+variable "private_subnet_cidr_block" {
+  description = "The CIDR block for the private subnet"
+  type        = string
+  default     = "10.0.2.0/24"
+}
+
+variable "ssh_allowed_ip" {
+  description = "Allowed ip address for SSH access"
+  type        = string
+  default     = "0.0.0.0/0"
+}
+
+variable "ubuntu_ami" {
+  description = "AMIs for Ubuntu 22.04 instances"
+  type        = string
+  default     = "ami-005fc0f236362e99f"
+}
+
+variable "key_pair" {
+  description = "Key pair for the EC2 instance"
+  type        = string
+  default     = "own-cloud"
+}

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,0 +1,81 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+locals {
+  common_tags = {
+    Terraform = "true"
+    Owncloud  = "true"
+  }
+}
+
+resource "aws_vpc" "owncloud-vpc" {
+  cidr_block       = var.vpc_cidr_block
+  instance_tenancy = "default"
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = var.vpc_name
+    }
+  )
+}
+
+resource "aws_subnet" "public_subnet" {
+  vpc_id                  = aws_vpc.owncloud-vpc.id
+  cidr_block              = var.public_subnet_cidr_block
+  availability_zone       = "us-east-1a"
+  map_public_ip_on_launch = true
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "public_subnet"
+    }
+  )
+}
+
+resource "aws_subnet" "private_subnet" {
+  vpc_id            = aws_vpc.owncloud-vpc.id
+  cidr_block        = var.private_subnet_cidr_block
+  availability_zone = "us-east-1b"
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "private_subnet"
+    }
+  )
+}
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.owncloud-vpc.id
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "igw"
+    }
+  )
+}
+
+resource "aws_route_table" "public_route_table" {
+  vpc_id = aws_vpc.owncloud-vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw.id
+  }
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "public_crt"
+    }
+  )
+}
+
+resource "aws_route_table_association" "public_rt_association" {
+  subnet_id      = aws_subnet.public_subnet.id
+  route_table_id = aws_route_table.public_route_table.id
+}


### PR DESCRIPTION
This commit introduces multiple infrastructure files required for setting up OwnCloud using Terraform. It includes configurations for AWS instances, VPC, subnets, security groups, and essential IntelliJ IDEA project settings.