### PR TITLE
Update AMI for MySQL server instance

### DIFF
--- a/ec2-instances.tf
+++ b/ec2-instances.tf
@@ -16,7 +16,7 @@ resource "aws_instance" "owncloud-server" {
 }
 
 resource "aws_instance" "mysql-server" {
-  ami           = var.ubuntu_ami
+  ami           = var.private_server_ami
   instance_type = "t2.micro"
   subnet_id     = aws_subnet.private_subnet.id
   key_name      = var.key_pair

--- a/variables.tf
+++ b/variables.tf
@@ -40,6 +40,11 @@ variable "ubuntu_ami" {
   default     = "ami-005fc0f236362e99f"
 }
 
+variable "private_server_ami" {
+  description = "Private server ami with mysql installed on it"
+  type        = string
+}
+
 variable "key_pair" {
   description = "Key pair for the EC2 instance"
   type        = string


### PR DESCRIPTION
Changed the AMI for the MySQL server from a general Ubuntu image to a private server AMI with MySQL pre-installed. Added a new Terraform variable for the private server AMI definition.